### PR TITLE
Added Development Information, Fixed Bower Dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,4 +37,8 @@ The first argument is the agenda instance. The second is an options object. Curr
 
 
 ### Developing
-This is an Ember app that gets built on `prepublish`. To try it out locally with some sample jobs run `npm run dev` and `ember serve` in the `/app` directory. You will also need to run `npm install` and `bower install` in the `app/` directory to install the ember app's dependencies. Then go to [http://localhost:3022/](http://localhost:3022/).
+This is an Ember app that gets built on `prepublish`.
+
+To build the app, you will need Bower installed globally (`npm install bower -g`).  After Bower is available, run `npm install` and then `bower install` in the `app/` directory.
+
+To run the application locally with sample jobs, run `npm run dev` and `ember serve` in the `/app` directory, then visit [http://localhost:3022/](http://localhost:3022/).

--- a/app/bower.json
+++ b/app/bower.json
@@ -13,6 +13,6 @@
     "ember-qunit-notifications": "^0.0.3",
     "ember-cli-test-loader": "rjackson/ember-cli-test-loader#0.0.2",
     "moment": "~2.8.2",
-    "bootstrap-sass-official": "~3.2.0+2"
+    "bootstrap-sass-official": "^3.2.0"
   }
 }


### PR DESCRIPTION
After running into some trouble building the application for
development, I found that Bower had to be installed globally.

I added that information to the development section to the README
so that other developers attempting to build the project will
avoid problems.

There also was an issue with the bower.json file that prevented
the bower install to succeed.  I changed the Bootstrap dependency
to point to the latest 3.2.\* release, which fixes the build.

Fixes #3 
