### PR TITLE
Fix issue #7: Missing fonts

### DIFF
--- a/app/app/styles/variables.scss
+++ b/app/app/styles/variables.scss
@@ -10,7 +10,7 @@ $sidebar-width: 250px;
 $grid-float-breakpoint: 100px;
 $navbar-default-brand-color: $brand-color;
 $brand-primary: $brand-color;
-$font-family-base: "Proxima Nova", "Helvetica Neue";
+$font-family-base: "Proxima Nova", "Helvetica Neue", Helvetica, Arial, san-serif;
 $text-color: #7F8B91;
 $body-bg: $background-color;
 $navbar-default-bg: white;


### PR DESCRIPTION
Fix issue #7 where font-stack does not fallback gracefully for systems
without Proxima Nova and Helvetica Neue.

Since I don't think you can legally include non-open sourced font into github,
we just fix the font-stack to be more forgiving.